### PR TITLE
Switch to public Perl image and refine build/benchmark setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,12 @@
+.carmel/
+.idea/
 local/
 blib/
 cpanfile.snapshot
+MYMETA.json
+MYMETA.yml
+*.bs
+*.xsc
+pm_to_blib
+Makefile
+Makefile.old

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-local/
-cpanfile.snapshot
 .carmel/
 .idea/
+local/
+blib/
+cpanfile.snapshot
 MYMETA.json
 MYMETA.yml
 *.bs

--- a/benchmark/benchmark.pl
+++ b/benchmark/benchmark.pl
@@ -13,27 +13,31 @@ use Valkey::Client;
 
 my $r = Redis->new(server => 'valkey:6379');
 my $rf = Redis::Fast->new(server => 'valkey:6379');
-my $vc = Valkey::Client->new(hostname => 'valkey', port => 6379);
+my $vc_ffi = Valkey::Client->new(use_ffi => 1, hostname => 'valkey', port => 6379);
+my $vc_xs = Valkey::Client->new(use_ffi => 0, hostname => 'valkey', port => 6379);
 
 my $i = 0;
 my $j = 0;
 my $k = 0;
+my $l = 0;
 
 timethese(
     -3,
     {
         'r:00_ping'  => sub { $r->ping },
         'rf:00_ping' => sub { $rf->ping },
-        'vc:00_ping' => sub { $vc->ping },
+        'vc_ffi:00_ping' => sub { $vc_ffi->ping },
+        'vc_xs:00_ping' => sub { $vc_xs->ping },
     }
 );
 
 timethese(
     -3,
     {
-        'r:10_set'  => sub { $r->set('foo', $i++) },
-        'rf:10_set' => sub { $rf->set('foo', $j++) },
-        'vc:10_set' => sub { $vc->set('foo', $k++) },
+        'r:10_set'  => sub { $r->set('r', $i++) },
+        'rf:10_set' => sub { $rf->set('rf', $j++) },
+        'vc_ffi:10_set' => sub { $vc_ffi->set('vc_ffi', $k++) },
+        'vc_xs:10_set' => sub { $vc_xs->set('vc_xs', $l++) },
     }
 );
 
@@ -42,16 +46,18 @@ timethese(
     {
         'r:11_set_r'  => sub { $r->set('bench-' . rand(), rand()) },
         'rf:11_set_r' => sub { $rf->set('bench-' . rand(), rand()) },
-        'vc:11_set_r' => sub { $vc->set('bench-' . rand(), rand()) },
+        'vc_ffi:11_set_r' => sub { $vc_ffi->set('bench-' . rand(), rand()) },
+        'vc_xs:11_set_r' => sub { $vc_xs->set('bench-' . rand(), rand()) },
     }
 );
 
 timethese(
     -3,
     {
-        'r:20_get'  => sub { $r->get('foo') },
-        'rf:20_get' => sub { $rf->get('foo') },
-        'vc:20_get' => sub { $vc->get('foo') },
+        'r:20_get'  => sub { $r->get('r') },
+        'rf:20_get' => sub { $rf->get('rf') },
+        'vc_ffi:20_get' => sub { $vc_ffi->get('vc_ffi') },
+        'vc_xs:20_get' => sub { $vc_xs->get('vc_xs') },
     }
 );
 
@@ -60,14 +66,15 @@ timethese(
     {
         'r:21_get_r'  => sub { $r->get('bench-' . rand()) },
         'rf:21_get_r' => sub { $rf->get('bench-' . rand()) },
-        'vc:21_get_r' => sub { $vc->get('bench-' . rand()) },
+        'vc_ffi:21_get_r' => sub { $vc_ffi->get('bench-' . rand()) },
+        'vc_xs:21_get_r' => sub { $vc_xs->get('bench-' . rand()) },
     }
 );
 
-# '30_incr'   => sub { $vc->incr('counter') },
-# '30_incr_r' => sub { $vc->incr('bench-' . rand()) },
-# '40_lpush'  => sub { $vc->lpush('mylist', 'bar') },
-# '40_lpush'  => sub { $vc->lpush('mylist', 'bar') },
-# '50_lpop'   => sub { $vc->lpop('mylist') },
+# '30_incr'   => sub { $vc_ffi->incr('counter') },
+# '30_incr_r' => sub { $vc_ffi->incr('bench-' . rand()) },
+# '40_lpush'  => sub { $vc_ffi->lpush('mylist', 'bar') },
+# '40_lpush'  => sub { $vc_ffi->lpush('mylist', 'bar') },
+# '50_lpop'   => sub { $vc_ffi->lpop('mylist') },
 # '90_h_set'  => sub { $hash{ 'test' . rand() } = rand() },
 # '90_h_get'  => sub { my $a = $hash{ 'test' . rand() }; },

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,12 +5,18 @@ services:
     mem_limit: 1g
     ports:
       - "6379:6379"
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
   app:
     build:
       context: .
       dockerfile: Dockerfile
     working_dir: /app
     volumes:
-      - .:/app
+      - ./benchmark:/app/benchmark
+      - ./lib:/app/lib
+      - ./t:/app/t
+      - ./Makefile.PL:/app/Makefile.PL
+      - ./cpanfile:/app/cpanfile
     depends_on:
       - valkey


### PR DESCRIPTION
Updated the Dockerfile to use a public Perl image from Amazon ECR and optimized the package installation process. Enhanced benchmarks to include FFI and XS variations, reorganized volume mappings in compose.yaml, and cleaned up .gitignore and .dockerignore for better cache handling. These changes improve clarity, consistency, and maintainability.